### PR TITLE
[bug] When cache is false, get is not to able to access cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,14 +32,13 @@ export default function Embeddings(arg1, arg2) {
 }
 
 Embeddings.prototype.fetch = async function (input) {
-    if (this.options.cache && !this.cache) {
-        this.cache = new Cache(this.options.cache_file);
-        await this.cache.load();
-    }
-
-
-    let embedding = await this.cache.get(input, this.model);
-    if (this.options.cache && embedding) {
+    let embedding;
+    if (this.options.cache) {
+        if (!this.cache) {
+            this.cache = new Cache(this.options.cache_file);
+            await this.cache.load();
+        }
+        embedding = await this.cache.get(input, this.model)
         log(`found cached embedding for ${this.service}/${this.model}`);
         return embedding;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,10 @@ Embeddings.prototype.fetch = async function (input) {
             await this.cache.load();
         }
         embedding = await this.cache.get(input, this.model)
-        log(`found cached embedding for ${this.service}/${this.model}`);
-        return embedding;
+        if( embedding ) {
+            log(`found cached embedding for ${this.service}/${this.model}`);
+            return embedding;
+        }
     }
 
     log(`fetching embedding from ${this.service}/${this.model} with ${JSON.stringify(this.options)}`);


### PR DESCRIPTION
When instantiating as follows
```
const embedding = await embeddings("hello world", {
        cache: false
 });
```

An error occurs:
`Cannot read properties of null (reading 'get')`

This is due to the fact that this.cache is null and therefor it stops working all together. This fixes this bug.